### PR TITLE
Fix: forecast display issue (on Firefox)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -124,7 +124,6 @@ form {
 #forecast {
     display: flex;
     flex-direction: row;        
-    justify-content: space-evenly; 
     align-items: center;        
     flex-wrap: nowrap;          
     width: 30em;      


### PR DESCRIPTION
Before:
<img width="454" alt="before" src="https://github.com/user-attachments/assets/8386ff88-8b05-4de2-b081-b11c81fe7a26" />

After:
<img width="453" alt="after" src="https://github.com/user-attachments/assets/f71a72d3-6f06-4cf6-8e55-feec09771227" />